### PR TITLE
BAU: Adjust the replication lambda schedule

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,4 +41,4 @@ functions:
             - "trade-tariff-be-rd-${sls:stage}"
             - "trade-tariff-alb-security-group-${sls:stage}"
     events:
-      - schedule: cron(0 21 * * ? *) # Run every day at 21:00 UTC
+      - schedule: cron(20 21 * * ? *) # Run every day at 21:20 UTC


### PR DESCRIPTION
# Pull request

## Jira Link

BAU

## What?

I have added/removed/altered:

- [x] Altered the schedule to run the replication lambda at 21:20

## Why?

I am doing this because:

- This is aimed at aligning with when the backup finishes that we're going
to replicate which currently puts us a day behind
