### PR TITLE
BAU: Enable graceful replication by clearing task connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
     curl               \
     libcurl            \
     libstdc++          \
-    postgresql13
+    postgresql13       \
+    jq
 
 FROM python-alpine AS build-image
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk add --no-cache \
     libcurl            \
     libstdc++          \
     postgresql13       \
-    jq
+    jq                 \
+    bash
 
 FROM python-alpine AS build-image
 RUN apk add --no-cache \

--- a/app.py
+++ b/app.py
@@ -6,6 +6,6 @@ print("Loading my function")
 
 def handler(event, context):
     print("Received event: " + json.dumps(event, indent=2))
-    subprocess.run("sh restore.sh".split(" "))
+    subprocess.run("bash restore.sh".split(" "))
     print("Process complete.")
     return 0

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
     exec /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric "$1"

--- a/restore.sh
+++ b/restore.sh
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
-[[ -n $DEBUG ]] && set -o xtrace
+[[ "$TRACE" ]] && set -o xtrace
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o noclobber
+
+declare -A SERVICE_COUNTS
 
 if [ "$ENVIRONMENT" = "" ]; then
   echo "You need to set the ENVIRONMENT environment variable."
@@ -40,8 +42,6 @@ export PGPASSWORD="$POSTGRES_PASSWORD" # env var needed for psql
 BACKEND_SERVICES="backend-admin-uk backend-admin-xi backend-uk backend-xi worker-uk worker-xi"
 BACKUP_FILE="tariff-merged-production.sql.gz"
 CLUSTER_NAME="trade-tariff-cluster-$ENVIRONMENT"
-
-declare -A SERVICE_COUNTS
 
 get_desired_count_for_service() {
     local service=$1

--- a/restore.sh
+++ b/restore.sh
@@ -73,7 +73,14 @@ stop_services() {
 
 start_services() {
   for service in $BACKEND_SERVICES; do
-      set_desired_count_for_service_to $service ${SERVICE_COUNTS[$service]}
+      local desired_count
+      desired_count=${SERVICE_COUNTS[$service]}
+
+      if [ $desired_count -eq 0 ]; then
+          desired_count=1
+      fi
+
+      set_desired_count_for_service_to $service $desired_count
   done
 }
 
@@ -95,4 +102,4 @@ cat after_restore.sql | psql -h "$POSTGRES_HOST"         \
 echo "Applied after restore SQL script"
 
 echo "Starting services"
-start_connected_tasks
+start_services

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,6 +27,18 @@ provider:
     POSTGRES_USER: ${env:POSTGRES_USER}
     BASIC_AUTH_PASSWORD: ${env:BASIC_AUTH_PASSWORD}
 
+  iamRoleStatements:
+    - Effect: "Allow"
+      Action:
+        - ecs:ListTasks
+        - ecs:StartTask
+        - ecs:StopTask
+      Resource:
+        - "arn:aws:ecs:eu-west-2:${aws:accountId}:cluster/trade-tariff-cluster-*"
+        - "arn:aws:ecs:eu-west-2:${aws:accountId}:task/trade-tariff-cluster-*"
+        - "arn:aws:ecs:eu-west-2:${aws:accountId}:service/trade-tariff-cluster-*"
+        - "arn:aws:ecs:eu-west-2:${aws:accountId}:container-instance/trade-tariff-cluster-*"
+
 functions:
   restore:
     image: database-replication

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,8 @@ provider:
         - ecs:ListTasks
         - ecs:StartTask
         - ecs:StopTask
+        - ecs:DescribeServices
+        - ecs:UpdateService
       Resource:
         - "arn:aws:ecs:eu-west-2:${aws:accountId}:cluster/trade-tariff-cluster-*"
         - "arn:aws:ecs:eu-west-2:${aws:accountId}:task/trade-tariff-cluster-*"


### PR DESCRIPTION
# Pull request

![image](https://github.com/user-attachments/assets/5470834f-a906-451c-b8cc-9749d68b3043)

## Jira Link

BAU

## What?

I have added/removed/altered:

- [x] Added handling for service database connections

## Why?

I am doing this because:

- This prevents any breakages in the execution of queries during the replication process
