### PR TITLE
HMRC-532: Replicate to Aurora database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,3 @@ workflows:
           stage: staging
           context: trade-tariff-database-backups-staging
           <<: *filter-main
-
-      - deploy:
-          name: deploy-staging-aurora
-          stage: staging-aurora
-          context: trade-tariff-database-backups-staging
-          <<: *filter-main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,3 +80,9 @@ workflows:
           stage: staging
           context: trade-tariff-database-backups-staging
           <<: *filter-main
+
+      - deploy:
+          name: deploy-staging-aurora
+          stage: staging-aurora
+          context: trade-tariff-database-backups-staging
+          <<: *filter-main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.0-beta
+    rev: v2.13.1-beta
     hooks:
       - id: hadolint-docker
 
@@ -11,7 +11,7 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "serverless-disable-functions": "^1.0.0",
     "serverless-plugin-utils": "^0.2.0",
     "serverless-vpc-discovery": "^4.1.0"
   }

--- a/restore.sh
+++ b/restore.sh
@@ -79,8 +79,8 @@ start_services() {
 echo "Stopping services"
 stop_services
 
-curl "https://tariff:$BASIC_AUTH_PASSWORD@dumps.trade-tariff.service.gov.uk/$BACKUP_FILE" -O
-gzip -d $BACKUP_FILE | psql $DATABASE_URL
+curl -o- "https://tariff:$BASIC_AUTH_PASSWORD@dumps.trade-tariff.service.gov.uk/$BACKUP_FILE" | \
+  gzip -d | psql $DATABASE_URL
 
 echo "SQL backup restored successfully"
 

--- a/restore.sh
+++ b/restore.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SECONDS=0
+
 [[ "$TRACE" ]] && set -o xtrace
 set -o errexit
 set -o nounset
@@ -13,23 +15,8 @@ if [ "$ENVIRONMENT" = "" ]; then
   exit 1
 fi
 
-if [ "$POSTGRES_DATABASE" = "" ]; then
-  echo "You need to set the POSTGRES_DATABASE environment variable."
-  exit 1
-fi
-
-if [ "$POSTGRES_HOST" = "" ]; then
-  echo "You need to set the POSTGRES_HOST environment variable."
-  exit 1
-fi
-
-if [ "$POSTGRES_USER" = "" ]; then
-  echo "You need to set the POSTGRES_USER environment variable."
-  exit 1
-fi
-
-if [ "$POSTGRES_PASSWORD" = "" ]; then
-  echo "You need to set the POSTGRES_PASSWORD environment variable or link to a container named POSTGRES."
+if [ "$DATABASE_SECRET" = "" ]; then
+  echo "You need to set the DATABASE_SECRET environment variable."
   exit 1
 fi
 
@@ -38,10 +25,15 @@ if [ "$BASIC_AUTH_PASSWORD" = "" ]; then
   exit 1
 fi
 
-export PGPASSWORD="$POSTGRES_PASSWORD" # env var needed for psql
 BACKEND_SERVICES="backend-admin-uk backend-admin-xi backend-uk backend-xi worker-uk worker-xi"
 BACKUP_FILE="tariff-merged-production.sql.gz"
 CLUSTER_NAME="trade-tariff-cluster-$ENVIRONMENT"
+
+DATABASE_URL=$(aws secretsmanager get-secret-value \
+  --secret-id $DATABASE_SECRET \
+  --query SecretString \
+  --output text
+)
 
 get_desired_count_for_service() {
     local service=$1
@@ -87,19 +79,16 @@ start_services() {
 echo "Stopping services"
 stop_services
 
-curl -o- "https://tariff:$BASIC_AUTH_PASSWORD@dumps.trade-tariff.service.gov.uk/$BACKUP_FILE" | \
-  gzip -d | \
-  psql -h "$POSTGRES_HOST"         \
-  -U "$POSTGRES_USER"              \
-  -d "$POSTGRES_DATABASE"
+curl "https://tariff:$BASIC_AUTH_PASSWORD@dumps.trade-tariff.service.gov.uk/$BACKUP_FILE" -O
+gzip -d $BACKUP_FILE | psql $DATABASE_URL
 
 echo "SQL backup restored successfully"
 
-cat after_restore.sql | psql -h "$POSTGRES_HOST"         \
-  -U "$POSTGRES_USER"              \
-  -d "$POSTGRES_DATABASE"
+cat after_restore.sql | psql $DATABASE_URL
 
 echo "Applied after restore SQL script"
 
 echo "Starting services"
 start_services
+
+echo "Database replication complete. Time: ${SECONDS}s"

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,6 +4,12 @@ service: database-replication
 plugins:
   - serverless-vpc-discovery
   - serverless-plugin-utils
+  - serverless-disable-functions
+
+custom:
+  enable_aurora:
+    development: false
+    staging: true
 
 provider:
   name: aws
@@ -21,10 +27,6 @@ provider:
 
   environment:
     ENVIRONMENT: ${sls:stage}
-    POSTGRES_DATABASE: "TradeTariffPostgres${capitalize(${sls:stage})}"
-    POSTGRES_HOST: ${env:POSTGRES_HOST}
-    POSTGRES_PASSWORD: ${env:POSTGRES_PASSWORD}
-    POSTGRES_USER: ${env:POSTGRES_USER}
     BASIC_AUTH_PASSWORD: ${env:BASIC_AUTH_PASSWORD}
 
   iamRoleStatements:
@@ -41,9 +43,40 @@ provider:
         - "arn:aws:ecs:eu-west-2:${aws:accountId}:service/trade-tariff-cluster-*"
         - "arn:aws:ecs:eu-west-2:${aws:accountId}:container-instance/trade-tariff-cluster-*"
 
+    - Effect: "Allow"
+      Action:
+        - secretsmanager:GetResourcePolicy
+        - secretsmanager:GetSecretValue
+        - secretsmanager:DescribeSecret
+        - secretsmanager:ListSecretVersionIds
+      Resource:
+        - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:tradetariffpostgres${sls:stage}-connection-string-*"
+        - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:aurora-postgres-rw-connection-string-*"
+
 functions:
   restore:
     image: database-replication
+    environment:
+      DATABASE_SECRET: "tradetariffpostgres${sls:stage}-connection-string"
+    vpcDiscovery:
+      vpcName: "trade-tariff-${sls:stage}-vpc"
+      subnets:
+        - tagKey: "Name"
+          tagValues:
+            - "*private*"
+      securityGroups:
+        - names:
+            - "trade-tariff-be-rd-${sls:stage}"
+            - "trade-tariff-alb-security-group-${sls:stage}"
+    events:
+      - schedule: cron(20 21 * * ? *) # Run every day at 21:20 UTC
+
+  restore-aurora:
+    enabled: ${self:custom.aurora_enabled.${sls:stage}}
+
+    image: database-replication
+    environment:
+      DATABASE:SECRET: "aurora-postgres-rw-connection-string"
     vpcDiscovery:
       vpcName: "trade-tariff-${sls:stage}-vpc"
       subnets:

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,8 +63,10 @@ provider:
         - kms:GenerateDataKeyPairWithoutPlainText
         - kms:GenerateDataKeyWithoutPlaintext
       Resource:
-        - arn:aws:kms:eu-west-2:${aws:accountId}:alias/secretsmanager-key
-        - "*"
+        - arn:aws:kms:eu-west-2:${aws:accountId}:key/*
+      Condition:
+        "ForAnyValue:StringLike":
+          "kms:ResourceAliases": "alias/secretsmanager*"
 
 functions:
   restore:

--- a/serverless.yml
+++ b/serverless.yml
@@ -72,7 +72,7 @@ functions:
       - schedule: cron(20 21 * * ? *) # Run every day at 21:20 UTC
 
   restore-aurora:
-    enabled: ${self:custom.aurora_enabled.${sls:stage}}
+    enabled: ${self:custom.enable_aurora.${sls:stage}}
 
     image: database-replication
     environment:

--- a/serverless.yml
+++ b/serverless.yml
@@ -53,6 +53,18 @@ provider:
         - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:tradetariffpostgres${sls:stage}-connection-string-*"
         - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:aurora-postgres-rw-connection-string-*"
 
+    - Effect: "Allow"
+      Action:
+        - kms:Encrypt
+        - kms:Decrypt
+        - kms:ReEncryptFrom
+        - kms:ReEncryptTo
+        - kms:GenerateDataKeyPair
+        - kms:GenerateDataKeyPairWithoutPlainText
+        - kms:GenerateDataKeyWithoutPlaintext
+      Resource:
+        - arn:aws:kms:eu-west-2:${aws:accountId}:alias/secretsmanager-key
+
 functions:
   restore:
     image: database-replication
@@ -76,7 +88,7 @@ functions:
 
     image: database-replication
     environment:
-      DATABASE:SECRET: "aurora-postgres-rw-connection-string"
+      DATABASE_SECRET: "aurora-postgres-rw-connection-string"
     vpcDiscovery:
       vpcName: "trade-tariff-${sls:stage}-vpc"
       subnets:

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,6 +64,7 @@ provider:
         - kms:GenerateDataKeyWithoutPlaintext
       Resource:
         - arn:aws:kms:eu-west-2:${aws:accountId}:alias/secretsmanager-key
+        - "*"
 
 functions:
   restore:

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,11 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
+serverless-disable-functions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/serverless-disable-functions/-/serverless-disable-functions-1.0.0.tgz#d93ac66084e829f93542220c2c2a5410a1339c4b"
+  integrity sha512-wUfndxhUlfK8ICqeSWqoAHUtotWlRYGffAeuqwp7iwqkM/utch3XO6i+0H7mkOx3X/Zd1G4A9ivzvZg0Vo9JYw==
+
 serverless-plugin-utils@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/serverless-plugin-utils/-/serverless-plugin-utils-0.2.0.tgz#6c82d1d0302cb2d902a4927a0156ba3b4fcb997b"


### PR DESCRIPTION
# Pull request

## Jira Link

[HMRC-532](https://transformuk.atlassian.net/browse/HMRC-532)

## What?

I have added/removed/altered:

- Added `Aurora` version of Lambda that deploys only in staging (where we are trialing Aurora).
- Removed `POSTGRES_*` secrets.
- Added secret fetch from SecretsManager.

## Why?

I am doing this because:

- As part of testing Aurora, we need to keep that database replicated as we do with the standard RDS Postgres instance.
- We can just fetch the database connection strings from SecretsManager, we don't have to store all those secrets in CircleCi (making the context weigh less)